### PR TITLE
feat: Add emoji reaction support for PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ It is a experimental project and may contain bugs. Use at your own risk.
 - ✅ **Inline diff** - Built-in diff visualization (no gitsigns required)
 
 ### Comment Management
-- 💬 **View comments inline** - PR comments appear as virtual text
+- 💬 **View comments inline** - PR comments appear as virtual text with reactions
 - 💬 **Add line comments** - Comment on specific lines with context
 - 💬 **Pending comments** - Draft comments locally, submit all at once
 - 💬 **List all comments** - Browse all PR comments (posted + pending) with file preview
 - 💬 **Reply to comments** - Continue conversation threads
 - 💬 **Edit/Delete** - Modify or remove your comments
 - 💬 **Comment threads** - View full conversation context when replying
+- 👍 **Emoji reactions** - Add/remove GitHub reactions (👍 👎 😄 🎉 😕 ❤️ 🚀 👀) to comments
 
 ### Review Actions
 - ✓ **Approve PRs** - Submit approval with optional comment
@@ -191,6 +192,7 @@ require("github-pr-reviewer").setup({
 | `:PRReply` | Reply to a comment on the current line |
 | `:PREditComment` | Edit your comment (works for both pending and posted) |
 | `:PRDeleteComment` | Delete your comment on the current line |
+| `:PRToggleReaction` | Toggle emoji reaction on a comment at the current line |
 
 ### Review Actions
 
@@ -216,6 +218,7 @@ From the menu, press:
 - `b` - Toggle review buffer (see all changed files)
 - `i` - Show PR info (stats, reviews, CI checks)
 - `o` - Open PR in browser
+- `R` - Toggle emoji reaction on comment at cursor
 - `a` - **Approve** the PR
 - `x` - **Request changes** on the PR
 - `c` - Cleanup and exit review mode
@@ -417,6 +420,14 @@ Benefits:
 - `:PRReply` - Reply to a comment (cannot reply to pending comments)
 - `:PREditComment` - Edit your comment (works for both pending and posted)
 - `:PRDeleteComment` - Delete your comment
+- `:PRToggleReaction` - Add or remove an emoji reaction to a comment
+
+**React to Comments:**
+- Position cursor on a line with a comment
+- Use `:PRToggleReaction` or press `R` in the `:PR` menu
+- Select an emoji (👍 👎 😄 🎉 😕 ❤️ 🚀 👀)
+- Selecting the same reaction again removes it (toggle behavior)
+- Reactions appear inline next to comment indicators and in comment previews
 
 **List All Comments** (`:PRListAllComments`):
 - Shows both pending and posted comments
@@ -539,6 +550,7 @@ vim.keymap.set("n", "<leader>pp", ":PRListPendingComments<CR>", { desc = "List p
 vim.keymap.set("n", "<leader>pR", ":PRReply<CR>", { desc = "Reply to comment" })
 vim.keymap.set("n", "<leader>pe", ":PREditComment<CR>", { desc = "Edit my comment" })
 vim.keymap.set("n", "<leader>pd", ":PRDeleteComment<CR>", { desc = "Delete my comment" })
+vim.keymap.set("n", "<leader>pE", ":PRToggleReaction<CR>", { desc = "Toggle emoji reaction" })
 
 -- Review actions
 vim.keymap.set("n", "<leader>pa", ":PRApprove<CR>", { desc = "Approve PR" })

--- a/lua/github-pr-reviewer/ui.lua
+++ b/lua/github-pr-reviewer/ui.lua
@@ -721,4 +721,38 @@ function M.select_global_comments(comments, picker, callback)
   end
 end
 
+-- Select emoji reaction
+function M.select_emoji_reaction(callback)
+  local reactions = {
+    { emoji = "👍", label = "👍 Thumbs Up", content = "+1" },
+    { emoji = "👎", label = "👎 Thumbs Down", content = "-1" },
+    { emoji = "😄", label = "😄 Laugh", content = "laugh" },
+    { emoji = "🎉", label = "🎉 Hooray", content = "hooray" },
+    { emoji = "😕", label = "😕 Confused", content = "confused" },
+    { emoji = "❤️", label = "❤️  Heart", content = "heart" },
+    { emoji = "🚀", label = "🚀 Rocket", content = "rocket" },
+    { emoji = "👀", label = "👀 Eyes", content = "eyes" },
+  }
+
+  local items = {}
+  local reaction_map = {}
+  for _, reaction in ipairs(reactions) do
+    table.insert(items, reaction.label)
+    reaction_map[reaction.label] = reaction.content
+  end
+
+  vim.ui.select(items, {
+    prompt = "Select emoji reaction:",
+    format_item = function(item)
+      return item
+    end,
+  }, function(choice)
+    if choice then
+      callback(reaction_map[choice])
+    else
+      callback(nil)
+    end
+  end)
+end
+
 return M


### PR DESCRIPTION
# Add emoji reaction support for PR comments

## Overview
Adds GitHub-style emoji reactions to PR review comments, allowing reviewers to quickly express feedback without writing full comments.

## Features

### Reaction Management
- **Toggle reactions** on any posted comment via `:PRToggleReaction` or menu shortcut `R`
- **8 supported reactions**: 👍 👎 😄 🎉 😕 ❤️ 🚀 👀 (matching GitHub's reaction set)
- **Smart toggle**: Adding an existing reaction removes it, just like GitHub

### Visual Display
- **Inline display**: Reactions appear next to comment indicators with counts (e.g., `💬 2 comments 👍 3 ❤️`)
- **Hover preview**: Comment float window shows reactions below each comment
- **Aggregated counts**: Multiple reactions of the same type are counted and displayed together

### User Experience
- **Multi-comment handling**: When multiple comments exist on a line, prompts to select which comment to react to
- **Emoji picker**: Clean UI for selecting reactions using `vim.ui.select`
- **Menu integration**: Added "Toggle Reaction" to the PR review menu under Line Comment actions

## Implementation Details

### API Integration
- Uses GitHub's pull request review comment reactions API (`/pulls/comments/{id}/reactions`)
- Fetches reactions automatically when loading comments
- Caches reactions with comment data for performance

### Technical Highlights
- Graceful error handling with informative error messages
- Defensive nil checks to handle malformed reaction data
- Efficient reaction fetching using parallel async requests
- Proper reaction data initialization for pending/local comments

## Files Modified
- `lua/github-pr-reviewer/github.lua` - API functions for get/add/remove reactions
- `lua/github-pr-reviewer/init.lua` - Reaction display, toggle logic, command, menu integration
- `lua/github-pr-reviewer/ui.lua` - Emoji reaction picker

## Usage
```vim
" Position cursor on a line with a comment
:PRToggleReaction

" Or use the PR menu
:PR
" Press 'R' to toggle reaction
```

## Testing
- ✅ Add reaction to comment
- ✅ Remove reaction (toggle same reaction twice)
- ✅ Multiple reactions on same comment
- ✅ Multiple comments on same line
- ✅ Reactions display in inline view
- ✅ Reactions display in hover preview
- ✅ Reactions display in split/unified diff modes
