### PR TITLE
feat: add config option for max num of listed PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ require("github-pr-reviewer").setup({
   -- Show floating windows with PR info, stats, and keymaps
   show_floats = true,
 
+  -- Max number of PRs to fetch when listing (default: 30)
+  pr_list_limit = 30,
+
   -- Key to mark file as viewed and go to next file (only works in review mode)
   mark_as_viewed_key = "<CR>",
 

--- a/lua/github-pr-reviewer/github.lua
+++ b/lua/github-pr-reviewer/github.lua
@@ -11,7 +11,11 @@ local function debug_log(msg)
 end
 
 function M.list_open_prs()
-  local result = vim.fn.system("gh pr list --state open --json number,title,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,labels,headRefOid")
+  local pr_reviewer = require("github-pr-reviewer")
+  local result = vim.fn.system(
+    string.format("gh pr list --state open --limit %d --json number,title,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,labels,headRefOid",
+      pr_reviewer.config.pr_list_limit)
+  )
 
   if vim.v.shell_error ~= 0 then
     return nil, "Failed to fetch PRs. Make sure 'gh' CLI is installed and authenticated."
@@ -113,7 +117,11 @@ function M.get_pr_details(pr_number, callback)
 end
 
 function M.list_review_requests(callback)
-  local cmd = "gh pr list --search 'is:open review-requested:@me' --json number,title,headRefName,baseRefName,author,updatedAt,additions,deletions,headRepositoryOwner,headRepository,isCrossRepository"
+  local pr_reviewer = require("github-pr-reviewer")
+  local cmd = string.format(
+    "gh pr list --search 'is:open review-requested:@me' --limit %d --json number,title,headRefName,baseRefName,author,updatedAt,additions,deletions,headRepositoryOwner,headRepository,isCrossRepository",
+    pr_reviewer.config.pr_list_limit
+  )
 
   vim.fn.jobstart(cmd, {
     stdout_buffered = true,

--- a/lua/github-pr-reviewer/init.lua
+++ b/lua/github-pr-reviewer/init.lua
@@ -13,6 +13,7 @@ M.config = {
   show_inline_diff = true,        -- show inline diff in buffers (old lines as virtual text)
   show_floats = true,             -- show floating windows with info, stats and keymaps
   debug = false,                  -- show debug messages
+  pr_list_limit = 30,             -- max PRs to fetch when listing
   mark_as_viewed_key = "<CR>",    -- key to mark file as viewed and go to next file
   next_hunk_key = "<C-j>",        -- key to jump to next hunk
   prev_hunk_key = "<C-k>",        -- key to jump to previous hunk


### PR DESCRIPTION
The previous behavior was capped at retrieving 30 PRs (default `--limit` in `gh`), even if you had more PRs that you wanted to list. The new behavior now allows you to configure the max number of PRs that you want to retrieve using `gh` by changing the `pr_list_limit` in the config.