### PR TITLE
fix: preserve UTF-8 bytes in file paths when shell-quoting for git commands

### DIFF
--- a/lua/github-pr-reviewer/git.lua
+++ b/lua/github-pr-reviewer/git.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+-- POSIX-safe path quoting that preserves UTF-8 bytes unlike vim.fn.shellescape()
+-- which escapes multi-byte characters as octal sequences that git can't parse.
+local function shell_escape_path(path)
+  return "'" .. path:gsub("'", "'\\''") .. "'"
+end
+
 -- Debug logging helper
 local function debug_log(msg)
   local pr_reviewer = require("github-pr-reviewer")
@@ -184,7 +190,7 @@ local function checkout_pr_files_from_merge_head(merge_base, callback)
           callback()
           return
         end
-        local files_str = table.concat(vim.tbl_map(vim.fn.shellescape, pr_files), " ")
+        local files_str = table.concat(vim.tbl_map(shell_escape_path, pr_files), " ")
         vim.fn.jobstart("git checkout MERGE_HEAD -- " .. files_str, {
           on_exit = function()
             vim.schedule(callback)
@@ -314,7 +320,7 @@ function M.get_modified_files_with_lines(callback)
   local pending = #files
   for i, file in ipairs(files) do
     if file.status ~= "D" and file.status ~= "?" then
-      local diff_cmd = string.format("git diff --unified=0 %s -- %s", base_ref, vim.fn.shellescape(file.path))
+      local diff_cmd = string.format("git diff --unified=0 %s -- %s", base_ref, shell_escape_path(file.path))
       vim.fn.jobstart(diff_cmd, {
         stdout_buffered = true,
         on_stdout = function(_, data)
@@ -388,9 +394,9 @@ function M.cleanup_review(review_branch, target_branch, callback)
 
   for _, file in ipairs(files) do
     if file.status == "A" or file.status == "?" then
-      table.insert(new_paths, vim.fn.shellescape(file.path))
+      table.insert(new_paths, shell_escape_path(file.path))
     else
-      table.insert(modified_paths, vim.fn.shellescape(file.path))
+      table.insert(modified_paths, shell_escape_path(file.path))
     end
   end
 

--- a/lua/github-pr-reviewer/git.lua
+++ b/lua/github-pr-reviewer/git.lua
@@ -173,7 +173,7 @@ local function checkout_pr_files_from_merge_head(merge_base, callback)
     callback()
     return
   end
-  local diff_cmd = string.format("git diff --name-only --diff-filter=AM %s MERGE_HEAD", merge_base)
+  local diff_cmd = string.format("git -c core.quotePath=false diff --name-only --diff-filter=AM %s MERGE_HEAD", merge_base)
   vim.fn.jobstart(diff_cmd, {
     stdout_buffered = true,
     on_stdout = function(_, data)
@@ -281,7 +281,7 @@ end
 function M.get_modified_files_with_lines(callback)
   local merge_base = vim.g.pr_review_merge_base
   local base_ref = merge_base and merge_base or "HEAD"
-  local result = vim.fn.system("git diff --name-status " .. base_ref)
+  local result = vim.fn.system("git -c core.quotePath=false diff --name-status " .. base_ref)
   vim.schedule(function()
     debug_log(string.format("Debug: git diff output (first 200 chars): %s", result:sub(1, 200)))
   end)
@@ -303,7 +303,7 @@ function M.get_modified_files_with_lines(callback)
     debug_log(string.format("Debug: Found %d files", #files))
   end)
 
-  local untracked = vim.fn.system("git ls-files --others --exclude-standard")
+  local untracked = vim.fn.system("git -c core.quotePath=false ls-files --others --exclude-standard")
   if vim.v.shell_error == 0 then
     for path in untracked:gmatch("[^\r\n]+") do
       if path and path ~= "" then

--- a/lua/github-pr-reviewer/init.lua
+++ b/lua/github-pr-reviewer/init.lua
@@ -291,7 +291,7 @@ local function collect_pr_files(callback)
   -- First get tracked changes (M, A, D)
   -- Compare with the base branch of the PR, not HEAD
   local base_branch = vim.g.pr_review_base_branch or "master"
-  local cmd = string.format("git diff --name-status origin/%s", base_branch)
+  local cmd = string.format("git -c core.quotePath=false diff --name-status origin/%s", base_branch)
   vim.fn.jobstart(cmd, {
     stdout_buffered = true,
     on_stdout = function(_, data)
@@ -317,7 +317,7 @@ local function collect_pr_files(callback)
       end
 
       -- Now get untracked files
-      local untracked_cmd = "git ls-files --others --exclude-standard"
+      local untracked_cmd = "git -c core.quotePath=false ls-files --others --exclude-standard"
       vim.fn.jobstart(untracked_cmd, {
         stdout_buffered = true,
         on_stdout = function(_, untracked_data)

--- a/lua/github-pr-reviewer/init.lua
+++ b/lua/github-pr-reviewer/init.lua
@@ -4,6 +4,12 @@ local github = require("github-pr-reviewer.github")
 local git = require("github-pr-reviewer.git")
 local ui = require("github-pr-reviewer.ui")
 
+-- POSIX-safe path quoting that preserves UTF-8 bytes unlike vim.fn.shellescape()
+-- which escapes multi-byte characters as octal sequences that git can't parse.
+M.shell_escape_path = function(path)
+  return "'" .. path:gsub("'", "'\\''") .. "'"
+end
+
 M.config = {
   branch_prefix = "reviewing_",
   picker = "native",              -- "native", "fzf-lua", "telescope"
@@ -397,11 +403,11 @@ local function get_changed_lines_for_file(file_path, status, callback)
   local cmd
   if status == "N" then
     -- For new/untracked files, compare with /dev/null
-    cmd = string.format("git diff --unified=0 --no-index /dev/null -- %s", vim.fn.shellescape(file_path))
+    cmd = string.format("git diff --unified=0 --no-index /dev/null -- %s", M.shell_escape_path(file_path))
   else
     local merge_base = vim.g.pr_review_merge_base
     local base_ref = merge_base and merge_base or "HEAD"
-    cmd = string.format("git diff --unified=0 %s -- %s", base_ref, vim.fn.shellescape(file_path))
+    cmd = string.format("git diff --unified=0 %s -- %s", base_ref, M.shell_escape_path(file_path))
   end
   vim.fn.jobstart(cmd, {
     stdout_buffered = true,
@@ -460,11 +466,11 @@ get_inline_diff = function(file_path, status, callback)
   -- For new/untracked files, use a different command to get all lines
   local cmd
   if status == "A" or status == "N" then
-    cmd = string.format("git diff --unified=0 --no-index /dev/null -- %s", vim.fn.shellescape(file_path))
+    cmd = string.format("git diff --unified=0 --no-index /dev/null -- %s", M.shell_escape_path(file_path))
   else
     local merge_base = vim.g.pr_review_merge_base
     local base_ref = merge_base and merge_base or "HEAD"
-    cmd = string.format("git diff --unified=0 %s -- %s", base_ref, vim.fn.shellescape(file_path))
+    cmd = string.format("git diff --unified=0 %s -- %s", base_ref, M.shell_escape_path(file_path))
   end
 
   vim.fn.jobstart(cmd, {
@@ -675,21 +681,21 @@ local function create_split_view(current_bufnr, file_path)
 
   -- Prefer merge-base (exact common ancestor, matches GitHub's diff base)
   if merge_base then
-    table.insert(attempts, string.format("%s:%s", merge_base, file_path))
+    table.insert(attempts, M.shell_escape_path(string.format("%s:%s", merge_base, file_path)))
   end
 
   -- If we have base_branch, try it as fallback
   if base_branch then
-    table.insert(attempts, string.format("origin/%s:%s", base_branch, file_path))
-    table.insert(attempts, string.format("%s:%s", base_branch, file_path))
+    table.insert(attempts, M.shell_escape_path(string.format("origin/%s:%s", base_branch, file_path)))
+    table.insert(attempts, M.shell_escape_path(string.format("%s:%s", base_branch, file_path)))
   end
 
   -- Fallback attempts
-  table.insert(attempts, string.format("origin/main:%s", file_path))
-  table.insert(attempts, string.format("origin/master:%s", file_path))
-  table.insert(attempts, string.format("main:%s", file_path))
-  table.insert(attempts, string.format("master:%s", file_path))
-  table.insert(attempts, string.format("HEAD~1:%s", file_path))
+  table.insert(attempts, M.shell_escape_path(string.format("origin/main:%s", file_path)))
+  table.insert(attempts, M.shell_escape_path(string.format("origin/master:%s", file_path)))
+  table.insert(attempts, M.shell_escape_path(string.format("main:%s", file_path)))
+  table.insert(attempts, M.shell_escape_path(string.format("master:%s", file_path)))
+  table.insert(attempts, M.shell_escape_path(string.format("HEAD~1:%s", file_path)))
 
   local base_content
   local success = false
@@ -1186,7 +1192,7 @@ local function open_file_safe(file, split_cmd)
     else
       -- Open deleted file from merge_base (the PR's base commit, matching GitHub's view)
       local del_ref = vim.g.pr_review_merge_base or "HEAD"
-      local cmd = string.format("git show %s:%s", del_ref, vim.fn.shellescape(file.path))
+      local cmd = string.format("git show %s:%s", del_ref, M.shell_escape_path(file.path))
       vim.fn.jobstart(cmd, {
         stdout_buffered = true,
         on_stdout = function(_, data)


### PR DESCRIPTION
## Problem

When a PR contains files with non-ASCII characters in their paths (e.g. emoji, accented chars), the diff is invisible — you see the filename in the review buffer but no changes are highlighted.

Example: `jarvis/🐧 fedora.sh`

Two independent bugs cause this:

### 1. Git `core.quotePath=true` (default) mangles paths on output

```bash
$ git diff --name-status HEAD
M       "jarvis/\360\237\220\247 fedora.sh"   # ← octal-escaped, can't resolve

$ git -c core.quotePath=false diff --name-status HEAD
M       jarvis/🐧 fedora.sh                    # ← raw UTF-8, works fine
```

The plugin uses `git diff --name-status` and `git ls-files` to discover PR files. With `quotePath=true`, the emoji is stored as `\360\237\220\247` in `M._review_files`. All subsequent `git diff` commands use this mangled path and fail silently → "no diff to show".

### 2. `vim.fn.shellescape()` re-mangles UTF-8 bytes

Even if the path is correct, `vim.fn.shellescape(path)` escapes multi-byte UTF-8 as octal sequences:

```lua
vim.fn.shellescape("jarvis/🐧 fedora.sh")
-- 'jarvis/\360\237\220\247 fedora.sh'   ← git can't parse this
```

## Fix

### Fix 1: Add `-c core.quotePath=false` to path-output commands

In `git.lua` and `init.lua`, all `git diff --name-status`, `git diff --name-only`, and `git ls-files` commands now use `-c core.quotePath=false`.

### Fix 2: Replace `vim.fn.shellescape(path)` with POSIX single-quote wrapping

Added `shell_escape_path(path)` that wraps the path in single quotes (POSIX-safe, preserves all bytes):

```lua
-- Before: octal-escapes multi-byte chars → git can't find file
"git diff --unified=0 HEAD -- " .. vim.fn.shellescape(file_path)

-- After: single quotes pass raw bytes through → git resolves correctly  
"git diff --unified=0 HEAD -- " .. M.shell_escape_path(file_path)
```

URL-based `vim.fn.shellescape()` calls are left as-is — those are correct.